### PR TITLE
Bump lambda from 2.15.15 to 2.15.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ project(':terraform-generator-aws') {
         implementation 'software.amazon.awssdk:directconnect:2.15.17'
         implementation 'software.amazon.awssdk:iam:2.15.15'
         implementation 'software.amazon.awssdk:apigateway:2.15.17'
-        implementation 'software.amazon.awssdk:lambda:2.15.15'
+        implementation 'software.amazon.awssdk:lambda:2.15.17'
         implementation 'software.amazon.awssdk:s3:2.15.15'
         implementation 'software.amazon.awssdk:acm:2.15.15'
         implementation 'software.amazon.awssdk:kms:2.15.17'


### PR DESCRIPTION
Bumps lambda from 2.15.15 to 2.15.17.

Signed-off-by: dependabot[bot] <support@github.com>